### PR TITLE
Allow breaks in trajectory

### DIFF
--- a/examples/wxWebMapApp/PolygonReader.cpp
+++ b/examples/wxWebMapApp/PolygonReader.cpp
@@ -16,8 +16,9 @@ PolygonReader::PolygonReader(wxString const& filename, std::vector<std::vector<w
     wxString meta;
 	size_t num_lines = file.GetLineCount(), line = 0;
     wxString s = file.GetFirstLine();
+	wxString prevName = {};
 	if (isPolygon) {
-		while (ReadPolygon(file, s, polygon, meta, isPolygon)) {
+		while (ReadPolygon(file, s, polygon, meta)) {
 			polygons.push_back(polygon);
 			metaData.push_back(meta);
 			if (file.Eof()) {
@@ -31,26 +32,53 @@ PolygonReader::PolygonReader(wxString const& filename, std::vector<std::vector<w
 			s = file.GetNextLine(); // Read line after empty line
 		}
 	} else {
+		unsigned long prevNum = 0;
 		wxMapPoint pt;
 		s = file.GetNextLine(); // Ignore header line 
+		const int numDigits = 4; // We assume image files end with at least four digits. If not, trajectories will simply not be split
 		while (!file.Eof()) {
 			wxArrayString tokens = wxStringTokenize(s, ",");
 			if (tokens.size() >= 3) {
+				// Get the last four characters and convert to integers
+				size_t len = tokens[0].length();
+				if (len >= numDigits) {
+					wxString sNum = tokens[0].SubString(len - numDigits, len - 1);
+					unsigned long thisNum;
+					if (sNum.ToULong(&thisNum)) {
+						// Name ends with (at least) four digits
+						if (thisNum != prevNum + 1) {
+							// This one does not follow immediatelly after previous one so 
+							// finalize trajectory and start a new one
+							if (polygon.size()) {
+								if (polygon.size() == 1) {
+									// Draw a tiny line to symbolize a point 
+									pt = polygon[0];
+									pt.x += 0.000001f;
+									polygon.push_back(pt);
+								}
+								polygons.push_back(polygon);
+								metaData.push_back(tokens[0]);
+							}
+							polygon.clear();
+						}
+						prevNum = thisNum;
+					}
+				}
 				sscanf(tokens[1].char_str(), "%f", &(pt[1])); // First in file is longitude, but we want latitude first
 				sscanf(tokens[2].char_str(), "%f", &(pt[0]));
-				// Ignore third height/altitude token for now since point is 2D
 				polygon.push_back(pt);
 			}
 
 			s = file.GetNextLine(); // Read line after empty line
 		}
-		polygons.push_back(polygon);
-		metaData.push_back(filename);
+		if (polygon.size()) {
+			polygons.push_back(polygon);
+			metaData.push_back(filename);
+		}
 	}
-
 }
 
-bool PolygonReader::ReadPolygon(wxTextFile& file, wxString &s, std::vector<wxMapPoint > &polygon, wxString &meta, bool isPolygon)
+bool PolygonReader::ReadPolygon(wxTextFile& file, wxString &s, std::vector<wxMapPoint > &polygon, wxString &meta)
 {
     polygon.clear(); // Start a new polygon
     meta = s;

--- a/examples/wxWebMapApp/PolygonReader.h
+++ b/examples/wxWebMapApp/PolygonReader.h
@@ -25,5 +25,5 @@ protected:
      * @param meta Name of polygon
      * @return True on success
     */
-    bool ReadPolygon(wxTextFile& file, wxString& s, std::vector<wxMapPoint >& polygon, wxString& meta, bool isPolygon);
+    bool ReadPolygon(wxTextFile& file, wxString& s, std::vector<wxMapPoint >& polygon, wxString& meta);
 };


### PR DESCRIPTION
If name ends with at least four digits, then split trajectory if there are gaps in enumerations.